### PR TITLE
Remove --save

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ embed.build();
 With NPM:
 
 ```sh
-npm install --save @ryukobot/paginationembed
+npm install @ryukobot/paginationembed
 ```
 
 or Yarn:


### PR DESCRIPTION
As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install.